### PR TITLE
Update Docker workflow to trigger on master branch push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,10 @@
 name: Docker Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
-    inputs:
-      release:
-        description: "Release (e.g., v1.9.0)"
-        required: true
+  push:
+    branches:
+      - 'master'
 
 permissions:
   contents: read


### PR DESCRIPTION
Modify the Docker workflow to trigger on pushes to the master branch instead of only on release events.