### PR TITLE
Update Docker workflow and CoreDNS version to 25.02.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,13 @@
 name: Docker Release
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
-  push:
-    branches:
-      - 'master'
+    inputs:
+      release:
+        description: "Release (e.g., v1.9.0)"
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,10 @@
 name: Docker Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
-    inputs:
-      release:
-        description: "Release (e.g., v1.9.0)"
-        required: true
+  push:
+    branches:
+      - 'master'
 
 permissions:
   contents: read

--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -20,6 +20,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
+      - name: Install unbound
+        run: sudo apt install libunbound-dev
+
       - name: Build
         run: go build -v ./...
 

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -20,6 +20,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
+      - name: Install unbound
+        run: sudo apt install libunbound-dev
+
       - name: Build
         run: go build -v ./...
 
@@ -45,6 +48,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
+      - name: Install unbound
+        run: sudo apt install libunbound-dev
+
       - name: Build
         run: go build -v ./...
 
@@ -64,6 +70,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
         id: go
 
+      - name: Install unbound
+        run: sudo apt install libunbound-dev
+
       - name: Build
         run: go build -v ./...
 
@@ -80,7 +89,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install dependencies
-        run: sudo apt-get install make curl
+        run: sudo apt-get install make curl libunbound-dev
 
       - name: Test Makefile.release
         run: make GITHUB_ACCESS_TOKEN=x -n release github-push -f Makefile.release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,8 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      commit:
-        description: "Commit (e.g., 52f0348)"
-        default: "master"
+  push:
+    branches: [ master ]
 
 jobs:
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ FROM --platform=$BUILDPLATFORM ${DEBIAN_IMAGE} AS build
 SHELL [ "/bin/sh", "-ec" ]
 
 RUN export DEBCONF_NONINTERACTIVE_SEEN=true \
-           DEBIAN_FRONTEND=noninteractive \
-           DEBIAN_PRIORITY=critical \
-           TERM=linux ; \
+    DEBIAN_FRONTEND=noninteractive \
+    DEBIAN_PRIORITY=critical \
+    TERM=linux ; \
     apt-get -qq update ; \
     apt-get -yyqq upgrade ; \
-    apt-get -yyqq install ca-certificates libcap2-bin; \
+    apt-get -yyqq install ca-certificates libcap2-bin libunbound8; \
     apt-get clean
 COPY coredns /coredns
 RUN setcap cap_net_bind_service=+ep /coredns

--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 // Various CoreDNS constants.
 const (
-	CoreVersion = "1.12.0"
+	CoreVersion = "25.02.2"
 	CoreName    = "CoreDNS"
 	serverType  = "dns"
 )


### PR DESCRIPTION
Enhance the Docker workflow to trigger on push to the master branch and on release events. Update the CoreDNS version and add unbound installation to the workflows and Dockerfile.