### PR TITLE
Update release workflow to use manual trigger with commit input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,11 @@
 name: Release
 
 on:
-  push:
-    branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit (e.g., 52f0348)"
+        default: "master"
 
 jobs:
   release:


### PR DESCRIPTION
Change the release workflow to allow manual triggering with a commit input instead of only on push to the master branch.