### PR TITLE
Install unbound in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
         id: info
+      - name: Install unbound
+        run: sudo apt install libunbound-dev
       - name: Build release binary
         run: make -f Makefile.release release
       - name: Build release binary sha256


### PR DESCRIPTION
Add installation of the `libunbound-dev` package to the release workflow to ensure necessary dependencies are available during the build process.