### PR TITLE
Update unbound installation command to use apt-get with -y flag

### DIFF
--- a/.github/workflows/go.coverage.yml
+++ b/.github/workflows/go.coverage.yml
@@ -21,7 +21,7 @@ jobs:
         id: go
 
       - name: Install unbound
-        run: sudo apt install libunbound-dev
+        run: sudo apt-get install -y libunbound-dev
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.test.yml
+++ b/.github/workflows/go.test.yml
@@ -21,7 +21,7 @@ jobs:
         id: go
 
       - name: Install unbound
-        run: sudo apt install libunbound-dev
+        run: sudo apt-get install -y libunbound-dev
 
       - name: Build
         run: go build -v ./...
@@ -49,7 +49,7 @@ jobs:
         id: go
 
       - name: Install unbound
-        run: sudo apt install libunbound-dev
+        run: sudo apt-get install -y libunbound-dev
 
       - name: Build
         run: go build -v ./...
@@ -71,7 +71,7 @@ jobs:
         id: go
 
       - name: Install unbound
-        run: sudo apt install libunbound-dev
+        run: sudo apt-get install -y libunbound-dev
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
         id: info
       - name: Install unbound
-        run: sudo apt install libunbound-dev
+        run: sudo apt-get install -y libunbound-dev
       - name: Build release binary
         run: make -f Makefile.release release
       - name: Build release binary sha256


### PR DESCRIPTION
Change the installation command for unbound to use `apt-get` with the `-y` flag for automatic confirmation. This improves the installation process in the workflow.