### PR TITLE
Update release notes for CoreDNS-25.02.2

### DIFF
--- a/notes/coredns-25.02.2.md
+++ b/notes/coredns-25.02.2.md
@@ -1,0 +1,23 @@
++++
+title = "CoreDNS-1.12.0 Release"
+description = "CoreDNS-1.12.0 Release Notes."
+tags = ["Release", "1.12.0", "Notes"]
+release = "1.12.0"
+date = "2024-11-21T00:00:00+00:00"
+author = "coredns"
++++
+
+This release adds some a feature:
+
+* New multisocket plugin - allows CoreDNS to listen on multiple sockets
+
+## Brought to You By
+
+Ben Kochie,
+Chris O'Haver,
+Emmanuel Ferdman,
+Viktor
+
+## Noteworthy Changes
+
+* plugin/multisocket (<https://github.com/coredns/coredns/pull/6882>)

--- a/notes/coredns-25.02.2.md
+++ b/notes/coredns-25.02.2.md
@@ -1,8 +1,8 @@
 +++
-title = "CoreDNS-1.12.0 Release"
-description = "CoreDNS-1.12.0 Release Notes."
-tags = ["Release", "1.12.0", "Notes"]
-release = "1.12.0"
+title = "CoreDNS-25.02.2 Release"
+description = "CoreDNS-25.02.2 Release Notes."
+tags = ["Release", "25.02.2", "Notes"]
+release = "25.02.2"
 date = "2024-11-21T00:00:00+00:00"
 author = "coredns"
 +++


### PR DESCRIPTION
Add detailed release notes for CoreDNS-25.02.2, including a new multisocket plugin feature and noteworthy changes.