### PR TITLE
Improve Dockerfile and Makefile.docker for build efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN setcap cap_net_bind_service=+ep /coredns
 
 FROM --platform=$TARGETPLATFORM ${BASE}
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /usr/lib/x86_64-linux-gnu /usr/lib/
 COPY --from=build /coredns /coredns
 USER nonroot:nonroot
 WORKDIR /

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -30,7 +30,7 @@ VERSION:=
 # DOCKER is the docker image repo we need to push to.
 DOCKER:=
 NAME:=coredns
-GITHUB:=https://github.com/coredns/coredns/releases/download
+GITHUB:=https://github.com/ton-bypass/coredns/releases/download
 # mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release
 LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x riscv64
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)


### PR DESCRIPTION
Enhance the Dockerfile by adding a library copy step and update the Makefile.docker to point to a new GitHub release URL.