### PR TITLE
Restrict supported Linux architectures in Docker Makefile

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -32,7 +32,7 @@ DOCKER:=
 NAME:=coredns
 GITHUB:=https://github.com/ton-bypass/coredns/releases/download
 # mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release
-LINUX_ARCH:=amd64 arm arm64 mips64le ppc64le s390x riscv64
+LINUX_ARCH:=amd64
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 DOCKER_IMAGE_LIST_VERSIONED:=$(shell echo $(LINUX_ARCH) | sed -e "s~mips64le ~~g" | sed -e "s~[^ ]*~$(DOCKER_IMAGE_NAME):&\-$(VERSION)~g")
 


### PR DESCRIPTION
Limit the supported Linux architectures to amd64 in the Docker Makefile to ensure compatibility with Docker manifest.