### PR TITLE
Update Docker image repository to tonbypass

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Build Docker Images
-        run: make VERSION=${RELEASE:1} DOCKER=coredns -f Makefile.docker release
+        run: make VERSION=${RELEASE:1} DOCKER=tonbypass -f Makefile.docker release
       - name: Show Docker Images
         run: docker images
       - name: Docker login
@@ -31,4 +31,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Publish Docker Images
-        run: make VERSION=${RELEASE:1} DOCKER=coredns -f Makefile.docker docker-push
+        run: make VERSION=${RELEASE:1} DOCKER=tonbypass -f Makefile.docker docker-push

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -28,7 +28,7 @@ endif
 # VERSION is the version we should download and use.
 VERSION:=
 # DOCKER is the docker image repo we need to push to.
-DOCKER:=
+DOCKER:=tonbypass
 NAME:=coredns
 GITHUB:=https://github.com/ton-bypass/coredns/releases/download
 # mips is not in LINUX_ARCH because it's not supported by docker manifest. Keep this list in sync with the one in Makefile.release


### PR DESCRIPTION
Change the Docker image repository reference in the Makefile and GitHub Actions workflow to tonbypass.