### PR TITLE
Update release date and add multisocket plugin to CoreDNS 1.12.0 release notes

### DIFF
--- a/notes/coredns-1.12.0.md
+++ b/notes/coredns-1.12.0.md
@@ -3,11 +3,12 @@ title = "CoreDNS-1.12.0 Release"
 description = "CoreDNS-1.12.0 Release Notes."
 tags = ["Release", "1.12.0", "Notes"]
 release = "1.12.0"
-date = "2024-11-21T00:00:00+00:00"
+date = "2025-02-03T00:00:00+00:00"
 author = "coredns"
 +++
 
 This release adds some a feature:
+
 * New multisocket plugin - allows CoreDNS to listen on multiple sockets
 
 ## Brought to You By
@@ -16,7 +17,6 @@ Ben Kochie,
 Chris O'Haver,
 Emmanuel Ferdman,
 Viktor
-
 
 ## Noteworthy Changes
 


### PR DESCRIPTION
Change the release date for CoreDNS 1.12.0 and include details about the new multisocket plugin feature in the release notes.